### PR TITLE
Update mod to Minecraft 1.18.x and Fabric 0.12.12

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,9 +27,9 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.7.4",
-    "fabric": "*",
-    "minecraft": "1.17.x"
+    "fabricloader": ">=0.12.12",
+    "fabric": "0.44.0",
+    "minecraft": "1.18.x"
   },
   "suggests": {
     "flamingo": "*"


### PR DESCRIPTION
I tested it, and its just working properly for me.
The mod will require now the latest Fabric Loader (0.12.12) and Fabric API (0.44.0) version, where the Log4J exploit is already fixed.
Have a nice day!
  - UbiOne