### PR TITLE
Update to 1.19.4 (fix #43)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop/
-	minecraft_version=1.19.3
-	yarn_mappings=1.19.3+build.5
-	loader_version=0.14.12
+	minecraft_version=1.19.4
+	yarn_mappings=1.19.4+build.2
+	loader_version=0.14.19
 
 # Mod Properties
 	mod_version = 2.1.0
 	maven_group = net.fabricmc
-	archives_base_name = fabric-elytra-autopilot-1.19.3
+	archives_base_name = fabric-elytra-autopilot-1.19.4
 
 # Dependencies
-	fabric_version=0.70.0+1.19.3
-	completeconfig_version = 2.2.0
+	fabric_version=0.80.0+1.19.4
+	completeconfig_version = 2.3.1

--- a/src/main/java/net/elytraautopilot/ElytraAutoPilot.java
+++ b/src/main/java/net/elytraautopilot/ElytraAutoPilot.java
@@ -115,7 +115,7 @@ public class ElytraAutoPilot implements ClientModInitializer {
                 int n = 2;
                 double c = clientPos.getY();
                 for (double i = c; i < l; i++) {
-                    BlockPos blockPos = new BlockPos(clientPos.getX(), clientPos.getY() + n, clientPos.getZ());
+                    BlockPos blockPos = BlockPos.ofFloored(clientPos.getX(), clientPos.getY() + n, clientPos.getZ());
                     if (!world.getBlockState(blockPos).isAir()) {
                         player.sendMessage(Text.translatable("text." + MODID + ".takeoffFail.clearSkyNeeded").formatted(Formatting.RED), true);
                         return;

--- a/src/main/java/net/elytraautopilot/utils/Hud.java
+++ b/src/main/java/net/elytraautopilot/utils/Hud.java
@@ -50,7 +50,7 @@ public class Hud {
             int l = world.getBottomY();
             Vec3d clientPos = player.getPos();
             for (double i = clientPos.getY(); i > l; i--) {
-                BlockPos blockPos = new BlockPos(clientPos.getX(), i, clientPos.getZ());
+                BlockPos blockPos = BlockPos.ofFloored(clientPos.getX(), i, clientPos.getZ());
                 if (world.getBlockState(blockPos).isSolidBlock(world, blockPos)) {
                     groundheight = clientPos.getY() - i;
                     break;


### PR DESCRIPTION
Updates to:

- Minecraft 1.19.4
- Fabric 0.80.0
- completeconfig 2.3.1

The 1.19.4 version of Minecraft introduced a breaking change which requires `BlockPos` constructors that take `double` types to instead use the `ofFloored` static method.

see: https://fabricmc.net/2023/03/01/1194.html